### PR TITLE
Setting default boot_disk_type to thin

### DIFF
--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -58,7 +58,7 @@ func resourceGUEST() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("boot_disk_type", nil),
+				DefaultFunc: schema.EnvDefaultFunc("boot_disk_type", "thin"),
 				Description: "Guest boot disk type. thin, zeroedthick, eagerzeroedthick",
 			},
 			"boot_disk_size": &schema.Schema{


### PR DESCRIPTION
Documentation says it's optional, but it was defaulting to nil, which was always results in state changes to boot_disk_type.