### PR TITLE
Change build path to /usr/local/lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provi
 
 ```sh
 
-export GOPATH="/usr/lib"
+export GOPATH="/usr/local/lib"
 go get -u golang.org/x/crypto/ssh
 
 mkdir -p $GOPATH/src/github.com/hashicorp


### PR DESCRIPTION
If we want to use lib folder to download all the dependencies and build the plugin we should use `/usr/local/lib` otherwise, the build process wont work in OSX Captain due the SIP.

Just changing this build process below `/usr/local` will work for OSX/linux environments.

**EXTRA INFO:**

- OSX Captain System Integrity Protection: https://support.apple.com/en-us/HT204899
- Filesystem Hierarchy Standard: https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard