### PR TITLE
Guest OS correction

### DIFF
--- a/esxi/guest-validations.go
+++ b/esxi/guest-validations.go
@@ -200,13 +200,13 @@ func validateGuestOsType(guestos string) bool {
     win98
     windows7-64
     windows7
-    windows7server-64
+    windows7srv-64
     windows8-64
     windows8
-    windows8server-64
+    windows8srv-64
     windows9-64
     windows9
-    windows9server-64
+    windows9srv-64
     windowshyperv
     winlonghorn-64
     winlonghorn

--- a/esxi/guest_update.go
+++ b/esxi/guest_update.go
@@ -50,6 +50,12 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	if virtualDiskCount > 59 {
 		virtualDiskCount = 59
 	}
+
+	// Validate guestOS
+	if validateGuestOsType(guestos) == false {
+		return errors.New("Error: invalid guestos.  see https://github.com/josenk/vagrant-vmware-esxi/wiki/VMware-ESXi-6.5-guestOS-types")
+	}
+
 	for i = 0; i < virtualDiskCount; i++ {
 		prefix := fmt.Sprintf("virtual_disks.%d.", i)
 


### PR DESCRIPTION
Some mistakes were done about the Windows Server 2008, 2012 & 2016 name.

Add the guestOS validation when update