### PR TITLE
Passing through guestinfo to VMs

### DIFF
--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -14,7 +14,9 @@ import (
 func guestCREATE(c *Config, guest_name string, disk_store string,
 	src_path string, resource_pool_name string, strmemsize string, strnumvcpus string, strvirthwver string, guestos string,
 	boot_disk_type string, boot_disk_size string, virtual_networks [4][3]string,
-	virtual_disks [60][2]string, guest_shutdown_timeout int, notes string) (string, error) {
+	virtual_disks [60][2]string, guest_shutdown_timeout int, notes string,
+	guestinfo map[string]interface{}) (string, error) {
+
 	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
 	log.Printf("[guestCREATE]\n")
 
@@ -241,7 +243,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 	//
 	//  make updates to vmx file
 	//
-	err = updateVmx_contents(c, vmid, true, memsize, numvcpus, virthwver, guestos, virtual_networks, virtual_disks, notes)
+	err = updateVmx_contents(c, vmid, true, memsize, numvcpus, virthwver, guestos, virtual_networks, virtual_disks, notes, guestinfo)
 	if err != nil {
 		return vmid, err
 	}

--- a/esxi/guest-delete.go
+++ b/esxi/guest-delete.go
@@ -10,6 +10,7 @@ import (
 func resourceGUESTDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
 	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	log.Println("[resourceGUESTDelete]")
 
 	var remote_cmd, stdout string
 	var err error
@@ -38,5 +39,6 @@ func resourceGUESTDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId("")
+
 	return nil
 }

--- a/esxi/guest_functions.go
+++ b/esxi/guest_functions.go
@@ -104,7 +104,9 @@ func readVmx_contents(c *Config, vmid string) (string, error) {
 }
 
 func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numvcpus int,
-	virthwver int, guestos string, virtual_networks [4][3]string, virtual_disks [60][2]string, notes string) error {
+	virthwver int, guestos string, virtual_networks [4][3]string, virtual_disks [60][2]string, notes string,
+	guestinfo map[string]interface{}) error {
+
 	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
 	log.Printf("[updateVmx_contents]\n")
 
@@ -158,6 +160,15 @@ func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numv
 			regexReplacement = fmt.Sprintf("\nannotation = \"%s\"", notes)
 			vmx_contents += regexReplacement
 		}
+	}
+
+	if len(guestinfo) > 0 {
+		parsed_vmx := ParseVMX(vmx_contents)
+		for k, v := range guestinfo {
+			log.Println("SAVING", k, v)
+			parsed_vmx["guestinfo."+k] = v.(string)
+		}
+		vmx_contents = EncodeVMX(parsed_vmx)
 	}
 
 	//

--- a/esxi/guest_update.go
+++ b/esxi/guest_update.go
@@ -10,7 +10,7 @@ import (
 
 func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	log.Printf("[guestUPDATE]\n")
+	log.Printf("[resourceGUESTUpdate]\n")
 
 	var virtual_networks [4][3]string
 	var virtual_disks [60][2]string
@@ -27,6 +27,11 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	notes := d.Get("notes").(string)
 	lanAdaptersCount := d.Get("network_interfaces.#").(int)
 	power := d.Get("power").(string)
+
+	guestinfo, ok := d.Get("guestinfo").(map[string]interface{})
+	if !ok {
+		return errors.New("guestinfo is wrong type")
+	}
 
 	if lanAdaptersCount > 3 {
 		lanAdaptersCount = 3
@@ -86,7 +91,7 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	imemsize, _ := strconv.Atoi(memsize)
 	inumvcpus, _ := strconv.Atoi(numvcpus)
 	ivirthwver, _ := strconv.Atoi(virthwver)
-	err = updateVmx_contents(c, vmid, false, imemsize, inumvcpus, ivirthwver, guestos, virtual_networks, virtual_disks, notes)
+	err = updateVmx_contents(c, vmid, false, imemsize, inumvcpus, ivirthwver, guestos, virtual_networks, virtual_disks, notes, guestinfo)
 	if err != nil {
 		fmt.Println("Failed to update VMX file.")
 		return errors.New("Failed to update VMX file.")
@@ -111,5 +116,5 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	return err
+	return resourceGUESTRead(d, m)
 }

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -212,6 +212,7 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 	guestos := d.Get("guestos").(string)
 	guest_shutdown_timeout := d.Get("guest_shutdown_timeout").(int)
 	notes := d.Get("notes").(string)
+	power := d.Get("power").(string)
 
 	guestinfo, ok := d.Get("guestinfo").(map[string]interface{})
 	if !ok {

--- a/esxi/vmx.go
+++ b/esxi/vmx.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ParseVMX parses the keys and values from a VMX file and returns
+// them as a Go map.
+func ParseVMX(contents string) map[string]string {
+	results := make(map[string]string)
+
+	lineRe := regexp.MustCompile(`^(.+?)\s*=\s*"(.*?)"\s*$`)
+
+	for _, line := range strings.Split(contents, "\n") {
+		matches := lineRe.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		results[matches[1]] = matches[2]
+	}
+
+	return results
+}
+
+// EncodeVMX takes a map and turns it into valid VMX contents.
+func EncodeVMX(contents map[string]string) string {
+	var buf bytes.Buffer
+
+	i := 0
+	keys := make([]string, len(contents))
+	for k, _ := range contents {
+		keys[i] = k
+		i++
+	}
+
+	sort.Strings(keys)
+	for _, k := range keys {
+		buf.WriteString(fmt.Sprintf("%s = \"%s\"\n", k, contents[k]))
+	}
+
+	return buf.String()
+}
+
+// WriteVMX takes a path to a VMX file and contents in the form of a
+// map and writes it out.
+func WriteVMX(path string, data map[string]string) (err error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	buf.WriteString(EncodeVMX(data))
+	if _, err = io.Copy(f, &buf); err != nil {
+		return
+	}
+
+	return
+}

--- a/esxi/vmx.go
+++ b/esxi/vmx.go
@@ -1,10 +1,9 @@
-package main
+package esxi
 
 import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"

--- a/esxi/vmx_test.go
+++ b/esxi/vmx_test.go
@@ -1,0 +1,39 @@
+package esxi
+
+import "testing"
+
+func TestParseVMX(t *testing.T) {
+	contents := `
+.encoding = "UTF-8"
+config.version = "8"
+`
+
+	results := ParseVMX(contents)
+	if len(results) != 2 {
+		t.Fatalf("not correct number of results: %d", len(results))
+	}
+
+	if results[".encoding"] != "UTF-8" {
+		t.Errorf("invalid .encoding: %s", results[".encoding"])
+	}
+
+	if results["config.version"] != "8" {
+		t.Errorf("invalid config.version: %s", results["config.version"])
+	}
+}
+
+func TestEncodeVMX(t *testing.T) {
+	contents := map[string]string{
+		".encoding":      "UTF-8",
+		"config.version": "8",
+	}
+
+	expected := `.encoding = "UTF-8"
+config.version = "8"
+`
+
+	result := EncodeVMX(contents)
+	if result != expected {
+		t.Errorf("invalid results: %s", result)
+	}
+}

--- a/examples/04 CoreOS/example.service
+++ b/examples/04 CoreOS/example.service
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/echo Hello World
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/04 CoreOS/main.tf
+++ b/examples/04 CoreOS/main.tf
@@ -1,0 +1,72 @@
+#########################################
+#  ESXI Provider host/login details
+#########################################
+#
+#   Use of variables here to hide/move the variables to a separate file
+#
+provider "esxi" {
+  version       = "~> 1.3"
+  esxi_hostname = "${var.esxi_hostname}"
+  esxi_hostport = "${var.esxi_hostport}"
+  esxi_username = "${var.esxi_username}"
+  esxi_password = "${var.esxi_password}"
+}
+
+data "ignition_user" "cluster_user" {
+  name = "core"
+  # used to calculate a password hash below if you want password: mkpasswd --method=SHA-512 --rounds=4096
+  #password_hash = "$6$rounds=4096$v28up9xdAO$aLCyf/FfGU72QsOlJN60CyXH5yuyJ/f6WWeW3wyvPjHt4uDOUFbFCxchrf9FCUkUdng7bwZbonBk7aOFQ8Bcm0" # test1234
+  ssh_authorized_keys = ["${file("~/.ssh/id_rsa.pub")}"]
+}
+
+data "ignition_systemd_unit" "example" {
+  name = "example.service"
+  content = "${file("example.service")}"
+}
+
+data "ignition_config" "coreos" {
+  users = [
+    "${data.ignition_user.cluster_user.id}"
+  ]
+
+  systemd = [
+    "${data.ignition_systemd_unit.example.id}"
+  ]
+}
+
+resource "esxi_guest" "coreos" {
+  guest_name = "${terraform.workspace}-coreos"
+  disk_store = "datastore0"
+
+  guestinfo = {
+    coreos.config.data.encoding = "base64"
+    coreos.config.data = "${base64encode(data.ignition_config.coreos.rendered)}"
+  }
+
+  # download the latest ova from coreos site
+  # curl -LO https://stable.release.core-os.net/amd64-usr/current/coreos_production_vmware_ova.ova
+  ovf_source = "coreos_production_vmware_ova.ova"
+  power = "on"
+  memsize  = "2048"
+  numvcpus = "2"
+  network_interfaces = [
+    {
+      virtual_network = "VM Network" # Required for each network interface, Specify the Virtual Network name.
+    },
+  ]
+
+  connection {
+    host     = "${self.ip_address}"
+    type     = "ssh"
+    user     = "core"
+    private_key = "${file("~/.ssh/id_rsa")}"
+    timeout = "60s"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo success",
+      #"update_engine_client -update",
+    ]
+  }
+}

--- a/examples/04 CoreOS/output.tf
+++ b/examples/04 CoreOS/output.tf
@@ -1,0 +1,3 @@
+output "ip" {
+  value = ["${esxi_guest.coreos.ip_address}"]
+}

--- a/examples/04 CoreOS/variables.tf
+++ b/examples/04 CoreOS/variables.tf
@@ -1,0 +1,19 @@
+#
+#  See https://www.terraform.io/intro/getting-started/variables.html for more details.
+#
+
+variable "esxi_hostname" {
+  default = "10.5.5.5"
+}
+
+variable "esxi_hostport" {
+  default = "22"
+}
+
+variable "esxi_username" {
+  default = "root"
+}
+
+variable "esxi_password" {
+  #default = ""
+} # Unspecified will prompt

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/terraform-providers/terraform-provider-esxi/esxi"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+	"terraform-provider-esxi/esxi"
 )
 
 func main() {


### PR DESCRIPTION
Adds the ability to pass through guestinfo to a VM.  This will allow you to stand up a CoreOS (I think any server that uses `cloud-init`) server with a default user / SSH key.  You can then hand this off to a provisioner to do the rest.

Somewhat solves #13

* Passing guestinfo through to the VMX file
* Added new library to parse VMX files (hopefully we can replace the hard-to-read regular expression parser we use now)
* Refactor resource manipulating functions to refresh state in a common way
* Adds example of how to deploy CoreOS instance

```
cd examples/04\ CoreOS
curl -LO https://stable.release.core-os.net/amd64-usr/current/coreos_production_vmware_ova.ova
terraform init
terraform plan -out deploy.out -var esxi_hostname=10.5.5.5
terraform apply deploy.out -var esxi_hostname=10.5.5.5
```

### Known issues

* Sometimes the machine won't receive the IP and the provisioning will fail (probably need to figure out a better method to grab the IP from the VM)