### PR TITLE
#55: Replace local import with remote

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"terraform-provider-esxi/esxi"
+	"github.com/terraform-providers/terraform-provider-esxi/esxi"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-esxi/esxi"
+	"github.com/josenk/terraform-provider-esxi/esxi"
 )
 
 func main() {


### PR DESCRIPTION
Replaced local import with remote, otherwise, the following error occurs:
`package terraform-provider-esxi/esxi: unrecognized import path "terraform-provider-esxi/esxi" (import path does not begin with hostname)`