### PR TITLE
chore(typos) fixed refactoring typos in example

### DIFF
--- a/examples/06 OVF Properties/main.tf
+++ b/examples/06 OVF Properties/main.tf
@@ -46,17 +46,17 @@ resource "esxi_guest" "vmtest" {
   #
   ovf_source        = var.ovf_file
 
-  ovf_property {
+  ovf_properties {
     key = "password"
     value = "Passw0rd1"
   }
 
-  ovf_property {
+  ovf_properties {
     key = "hostname"
     value = "HelloWorld"
   }
 
-  ovf_property {
+  ovf_properties {
     key = "user-data"
     value = base64encode(data.template_file.userdata_default.rendered)
   }


### PR DESCRIPTION
As property name was refactored, tf example should be refactored too. (small typos)