### PR TITLE
Add possibility to add extra configurations in esxi_guest resource

### DIFF
--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -238,7 +238,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 
 		if (len(ovf_extra_configs) > 0) && (strings.HasSuffix(src_path, ".ova") || strings.HasSuffix(src_path, ".ovf")) {
 			if (extra_params == "") {
-				extra_params = "--X:injectOvfEnv --allowAllExtraConfig --allowExtraConfig --powerOn "
+				extra_params = "--allowAllExtraConfig --allowExtraConfig "
 			}
 			
 			for ovf_extra_config_key, ovf_extra_config_value := range ovf_extra_configs {

--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -244,6 +244,9 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 			for ovf_extra_config_key, ovf_extra_config_value := range ovf_extra_configs {
 				extra_params = fmt.Sprintf("%s --extraConfig:%s=%s ", extra_params, ovf_extra_config_key, ovf_extra_config_value)
 			}
+		}
+
+		if (extra_params != "") {
 			log.Println("[guestCREATE] ovf_properties extra_params: " + extra_params)
 		}
 

--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -247,7 +247,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 		}
 
 		if (extra_params != "") {
-			log.Println("[guestCREATE] ovf_properties extra_params: " + extra_params)
+			log.Println("[guestCREATE] extra_params: " + extra_params)
 		}
 
 		ovf_cmd := fmt.Sprintf("ovftool --acceptAllEulas --noSSLVerify --X:useMacNaming=false %s "+


### PR DESCRIPTION
Added new block for adding extra configurations on ESXI guest. Also added both `--allowAllExtraConfig` and  `--allowExtraConfig` since those flags are broken (see https://communities.vmware.com/thread/576472).

Sample block:

```
ovf_extra_configs {
    key = "disk.enableUUID"
    value = "TRUE"
}
```