### PR TITLE
Added optional `esxi_hostssl` to provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ terraform {
 provider "esxi" {
   esxi_hostname      = "esxi"
   esxi_hostport      = "22"
+  esxi_hostssl       = "443"
   esxi_username      = "root"
   esxi_password      = "MyPassword"
 }
@@ -146,6 +147,7 @@ Configuration reference
 * provider "esxi"
   * esxi_hostname - Required
   * esxi_hostport - Optional - Default "22".
+  * esxi_hostssl - Optional - Default "443".
   * esxi_username - Optional - Default "root".
   * esxi_password - Required
 

--- a/esxi/config.go
+++ b/esxi/config.go
@@ -14,7 +14,7 @@ type Config struct {
 }
 
 func (c *Config) validateEsxiCreds() error {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[validateEsxiCreds]\n")
 
 	var remote_cmd string

--- a/esxi/config.go
+++ b/esxi/config.go
@@ -6,21 +6,22 @@ import (
 )
 
 type Config struct {
-	esxiHostName string
-	esxiHostPort string
-	esxiUserName string
-	esxiPassword string
+	esxiHostName    string
+	esxiHostSSHport string
+	esxiHostSSLport string
+	esxiUserName    string
+	esxiPassword    string
 }
 
 func (c *Config) validateEsxiCreds() error {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Printf("[validateEsxiCreds]\n")
 
 	var remote_cmd string
 	var err error
 
 	remote_cmd = fmt.Sprintf("vmware --version")
-	_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Connectivity test, get vmware version")
+	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Connectivity test, get vmware version")
 	if err != nil {
 		return fmt.Errorf("Failed to connect to esxi host: %s\n", err)
 	}

--- a/esxi/connection_info.go
+++ b/esxi/connection_info.go
@@ -1,0 +1,7 @@
+package esxi
+
+func getConnectionInfo(c *Config) ConnectionStruct {
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+
+	return esxiConnInfo
+}

--- a/esxi/esxi_main.go
+++ b/esxi/esxi_main.go
@@ -1,8 +1,9 @@
 package esxi
 
-type SshConnectionStruct struct {
-	host string
-	port string
-	user string
-	pass string
+type ConnectionStruct struct {
+	host    string
+	port    string
+	sslport string
+	user    string
+	pass    string
 }

--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -21,7 +21,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 	virtual_disks [60][2]string, guest_shutdown_timeout int, ovf_properties_timer int, notes string,
 	guestinfo map[string]interface{}, ovf_properties map[string]string) (string, error) {
 
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestCREATE]\n")
 
 	var memsize, numvcpus, virthwver int

--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -21,7 +21,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 	virtual_disks [60][2]string, guest_shutdown_timeout int, ovf_properties_timer int, notes string,
 	guestinfo map[string]interface{}, ovf_properties map[string]string) (string, error) {
 
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Printf("[guestCREATE]\n")
 
 	var memsize, numvcpus, virthwver int
@@ -73,17 +73,17 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 		boot_disk_vmdkPATH = fmt.Sprintf("\"/vmfs/volumes/%s/%s/%s.vmdk\"", disk_store, guest_name, guest_name)
 
 		remote_cmd = fmt.Sprintf("ls -d %s", boot_disk_vmdkPATH)
-		stdout, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "check if guest path already exists.")
+		stdout, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "check if guest path already exists.")
 		if strings.Contains(stdout, "No such file or directory") != true {
 			fmt.Printf("Error: Guest may already exists. vmdkPATH:%s\n", boot_disk_vmdkPATH)
 			return "", fmt.Errorf("Guest may already exists. vmdkPATH:%s\n", boot_disk_vmdkPATH)
 		}
 
 		remote_cmd = fmt.Sprintf("ls -d %s", fullPATH)
-		stdout, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "check if guest path already exists.")
+		stdout, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "check if guest path already exists.")
 		if strings.Contains(stdout, "No such file or directory") == true {
 			remote_cmd = fmt.Sprintf("mkdir %s", fullPATH)
-			stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "create guest path")
+			stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "create guest path")
 			if err != nil {
 				log.Printf("[guestCREATE] Failed to create guest path. fullPATH:%s\n", fullPATH)
 				return "", fmt.Errorf("Failed to create guest path. fullPATH:%s\n", fullPATH)
@@ -162,14 +162,14 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 		dst_vmx_file := fmt.Sprintf("%s/%s.vmx", fullPATH, guest_name)
 
 		remote_cmd = fmt.Sprintf("echo \"%s\" >%s", vmx_contents, dst_vmx_file)
-		vmx_contents, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "write guest_name.vmx file")
+		vmx_contents, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "write guest_name.vmx file")
 
 		//  Create boot disk (vmdk)
 		remote_cmd = fmt.Sprintf("vmkfstools -c %sG -d %s \"%s/%s.vmdk\"", boot_disk_size, boot_disk_type, fullPATH, guest_name)
-		_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "vmkfstools (make boot disk)")
+		_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "vmkfstools (make boot disk)")
 		if err != nil {
 			remote_cmd = fmt.Sprintf("rm -fr %s", fullPATH)
-			stdout, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "cleanup guest path because of failed events")
+			stdout, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "cleanup guest path because of failed events")
 			log.Printf("[guestCREATE] Failed to vmkfstools (make boot disk):%s\n", err.Error())
 			return "", fmt.Errorf("Failed to vmkfstools (make boot disk):%s\n", err.Error())
 		}
@@ -181,11 +181,11 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 			return "", fmt.Errorf("Failed to use Resource Pool ID:%s\n", poolID)
 		}
 		remote_cmd = fmt.Sprintf("vim-cmd solo/registervm %s %s %s", dst_vmx_file, guest_name, poolID)
-		_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "solo/registervm")
+		_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "solo/registervm")
 		if err != nil {
 			log.Printf("[guestCREATE] Failed to register guest:%s\n", err.Error())
 			remote_cmd = fmt.Sprintf("rm -fr %s", fullPATH)
-			stdout, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "cleanup guest path because of failed events")
+			stdout, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "cleanup guest path because of failed events")
 			return "", fmt.Errorf("Failed to register guest:%s\n", err.Error())
 		}
 
@@ -218,7 +218,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 			boot_disk_type = "thick"
 		}
 		password := url.QueryEscape(c.esxiPassword)
-		dst_path := fmt.Sprintf("vi://%s:%s@%s/%s", c.esxiUserName, password, c.esxiHostName, resource_pool_name)
+		dst_path := fmt.Sprintf("vi://%s:%s@%s:%s/%s", c.esxiUserName, password, c.esxiHostName, c.esxiHostSSLport, resource_pool_name)
 
 		net_param := ""
 		if (strings.HasSuffix(src_path, ".ova") || strings.HasSuffix(src_path, ".ovf")) && virtual_networks[0][0] != "" {

--- a/esxi/guest-delete.go
+++ b/esxi/guest-delete.go
@@ -10,7 +10,7 @@ import (
 
 func resourceGUESTDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourceGUESTDelete]")
 
 	var remote_cmd, stdout string

--- a/esxi/guest-delete.go
+++ b/esxi/guest-delete.go
@@ -2,14 +2,15 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceGUESTDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceGUESTDelete]")
 
 	var remote_cmd, stdout string
@@ -31,7 +32,7 @@ func resourceGUESTDelete(d *schema.ResourceData, m interface{}) error {
 
 	time.Sleep(5 * time.Second)
 	remote_cmd = fmt.Sprintf("vim-cmd vmsvc/destroy %s", vmid)
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "vmsvc/destroy")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "vmsvc/destroy")
 	if err != nil {
 		// todo more descriptive err message
 		log.Printf("[resourceGUESTDelete] Failed destroy vmid: %s\n", stdout)

--- a/esxi/guest-read.go
+++ b/esxi/guest-read.go
@@ -3,11 +3,12 @@ package esxi
 import (
 	"bufio"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceGUESTRead(d *schema.ResourceData, m interface{}) error {
@@ -83,7 +84,7 @@ func resourceGUESTRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, string, string, string, string, string, string, string, string, string, [10][3]string, [60][2]string, string, string, map[string]interface{}, error) {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[guestREAD]")
 
 	var guest_name, disk_store, virtual_disk_type, resource_pool_name, guestos, ip_address, notes string
@@ -97,7 +98,7 @@ func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, strin
 	r, _ := regexp.Compile("")
 
 	remote_cmd := fmt.Sprintf("vim-cmd  vmsvc/get.summary %s", vmid)
-	stdout, err := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get Guest summary")
+	stdout, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get Guest summary")
 
 	if strings.Contains(stdout, "Unable to find a VM corresponding") {
 		return "", "", "", "", "", "", "", "", "", "", virtual_networks, virtual_disks, "", "", nil, nil
@@ -121,7 +122,7 @@ func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, strin
 
 	//  Get resource pool that this VM is located
 	remote_cmd = fmt.Sprintf(`grep -A2 'objID>%s</objID' /etc/vmware/hostd/pools.xml | grep -o resourcePool.*resourcePool`, vmid)
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "check if guest is in resource pool")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "check if guest is in resource pool")
 	nr := strings.NewReplacer("resourcePool>", "", "</resourcePool", "")
 	vm_resource_pool_id := nr.Replace(stdout)
 	log.Printf("[GuestRead] resource_pool_name|%s| scanner.Text():|%s|\n", vm_resource_pool_id, stdout)
@@ -133,13 +134,13 @@ func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, strin
 	//
 	//      -Get location of vmx file on esxi host
 	remote_cmd = fmt.Sprintf("vim-cmd vmsvc/get.config %s | grep vmPathName|grep -oE \"\\[.*\\]\"", vmid)
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "get dst_vmx_ds")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "get dst_vmx_ds")
 	dst_vmx_ds = stdout
 	dst_vmx_ds = strings.Trim(dst_vmx_ds, "[")
 	dst_vmx_ds = strings.Trim(dst_vmx_ds, "]")
 
 	remote_cmd = fmt.Sprintf("vim-cmd vmsvc/get.config %s | grep vmPathName|awk '{print $NF}'|sed 's/[\"|,]//g'", vmid)
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "get dst_vmx")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "get dst_vmx")
 	dst_vmx = stdout
 
 	dst_vmx_file = "/vmfs/volumes/" + dst_vmx_ds + "/" + dst_vmx
@@ -148,7 +149,7 @@ func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, strin
 	log.Printf("[guestREAD] disk_store: %s  dst_vmx_ds:%s\n", disk_store, dst_vmx_file)
 
 	remote_cmd = fmt.Sprintf("cat \"%s\"", dst_vmx_file)
-	vmx_contents, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "read guest_name.vmx file")
+	vmx_contents, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "read guest_name.vmx file")
 
 	// Used to keep track if a network interface is using static or generated macs.
 	var isGeneratedMAC [10]bool

--- a/esxi/guest-read.go
+++ b/esxi/guest-read.go
@@ -84,7 +84,7 @@ func resourceGUESTRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, string, string, string, string, string, string, string, string, string, [10][3]string, [60][2]string, string, string, map[string]interface{}, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[guestREAD]")
 
 	var guest_name, disk_store, virtual_disk_type, resource_pool_name, guestos, ip_address, notes string

--- a/esxi/guest_functions.go
+++ b/esxi/guest_functions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func guestGetVMID(c *Config, guest_name string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestGetVMID]\n")
 
 	var remote_cmd, vmid string
@@ -31,7 +31,7 @@ func guestGetVMID(c *Config, guest_name string) (string, error) {
 }
 
 func guestValidateVMID(c *Config, vmid string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestValidateVMID]\n")
 
 	var remote_cmd string
@@ -51,7 +51,7 @@ func guestValidateVMID(c *Config, vmid string) (string, error) {
 }
 
 func getBootDiskPath(c *Config, vmid string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[getBootDiskPath]\n")
 
 	var remote_cmd, stdout string
@@ -69,7 +69,7 @@ func getBootDiskPath(c *Config, vmid string) (string, error) {
 }
 
 func getDst_vmx_file(c *Config, vmid string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[getDst_vmx_file]\n")
 
 	var dst_vmx_ds, dst_vmx, dst_vmx_file string
@@ -90,7 +90,7 @@ func getDst_vmx_file(c *Config, vmid string) (string, error) {
 }
 
 func readVmx_contents(c *Config, vmid string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[getVmx_contents]\n")
 
 	var remote_cmd, vmx_contents string
@@ -106,7 +106,7 @@ func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numv
 	virthwver int, guestos string, virtual_networks [10][3]string, virtual_disks [60][2]string, notes string,
 	guestinfo map[string]interface{}) error {
 
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[updateVmx_contents]\n")
 
 	var regexReplacement, remote_cmd string
@@ -342,7 +342,7 @@ func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numv
 }
 
 func cleanStorageFromVmx(c *Config, vmid string) error {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[cleanStorageFromVmx]\n")
 
 	var remote_cmd string
@@ -377,7 +377,7 @@ func cleanStorageFromVmx(c *Config, vmid string) error {
 }
 
 func guestPowerOn(c *Config, vmid string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestPowerOn]\n")
 
 	if guestPowerGetState(c, vmid) == "on" {
@@ -396,7 +396,7 @@ func guestPowerOn(c *Config, vmid string) (string, error) {
 }
 
 func guestPowerOff(c *Config, vmid string, guest_shutdown_timeout int) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestPowerOff]\n")
 
 	var remote_cmd, stdout string
@@ -434,7 +434,7 @@ func guestPowerOff(c *Config, vmid string, guest_shutdown_timeout int) (string, 
 }
 
 func guestPowerGetState(c *Config, vmid string) string {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestPowerGetState]\n")
 
 	remote_cmd := fmt.Sprintf("vim-cmd vmsvc/power.getstate %s", vmid)
@@ -455,7 +455,7 @@ func guestPowerGetState(c *Config, vmid string) string {
 }
 
 func guestGetIpAddress(c *Config, vmid string, guest_startup_timeout int) string {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[guestGetIpAddress]\n")
 
 	var remote_cmd, stdout, ip_address, ip_address2 string

--- a/esxi/provider.go
+++ b/esxi/provider.go
@@ -2,10 +2,11 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
 	"log"
 	"os"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func init() {
@@ -29,6 +30,12 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("esxi_hostport", "22"),
 				Description: "ssh port.",
+			},
+			"esxi_hostssl": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("exsi_hostssl", "443"),
+				Description: "ssl port.",
 			},
 			"esxi_username": &schema.Schema{
 				Type:        schema.TypeString,
@@ -54,10 +61,11 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		esxiHostName: d.Get("esxi_hostname").(string),
-		esxiHostPort: d.Get("esxi_hostport").(string),
-		esxiUserName: d.Get("esxi_username").(string),
-		esxiPassword: d.Get("esxi_password").(string),
+		esxiHostName:    d.Get("esxi_hostname").(string),
+		esxiHostSSHport: d.Get("esxi_hostport").(string),
+		esxiHostSSLport: d.Get("esxi_hostssl").(string),
+		esxiUserName:    d.Get("esxi_username").(string),
+		esxiPassword:    d.Get("esxi_password").(string),
 	}
 
 	if err := config.validateEsxiCreds(); err != nil {

--- a/esxi/resource-pool_create.go
+++ b/esxi/resource-pool_create.go
@@ -2,15 +2,16 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceRESOURCEPOOLCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceRESOURCEPOOLCreate]")
 
 	var remote_cmd string
@@ -108,7 +109,7 @@ func resourceRESOURCEPOOLCreate(d *schema.ResourceData, m interface{}) error {
 		cpu_min_opt, cpu_min_expandable_opt, cpu_max_opt, cpu_shares_opt,
 		mem_min_opt, mem_min_expandable_opt, mem_max_opt, mem_shares_opt, parent_pool_id, resource_pool_name)
 
-	_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "create resource pool")
+	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "create resource pool")
 	pool_id, _ = getPoolID(c, resource_pool_name)
 	if err != nil {
 		d.SetId("")

--- a/esxi/resource-pool_create.go
+++ b/esxi/resource-pool_create.go
@@ -11,7 +11,7 @@ import (
 
 func resourceRESOURCEPOOLCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourceRESOURCEPOOLCreate]")
 
 	var remote_cmd string

--- a/esxi/resource-pool_delete.go
+++ b/esxi/resource-pool_delete.go
@@ -9,7 +9,7 @@ import (
 
 func resourceRESOURCEPOOLDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourceRESOURCEPOOLDelete]")
 
 	var remote_cmd, stdout string

--- a/esxi/resource-pool_delete.go
+++ b/esxi/resource-pool_delete.go
@@ -2,13 +2,14 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceRESOURCEPOOLDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceRESOURCEPOOLDelete]")
 
 	var remote_cmd, stdout string
@@ -17,7 +18,7 @@ func resourceRESOURCEPOOLDelete(d *schema.ResourceData, m interface{}) error {
 	pool_id := d.Id()
 
 	remote_cmd = fmt.Sprintf("vim-cmd hostsvc/rsrc/destroy %s", pool_id)
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "destroy resource pool")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "destroy resource pool")
 	if err != nil {
 		// todo more descriptive err message
 		log.Printf("[resourcePoolDELETE] Failed destroy resource pool id: %s\n", stdout)

--- a/esxi/resource-pool_functions.go
+++ b/esxi/resource-pool_functions.go
@@ -12,7 +12,7 @@ import (
 
 //  Check if Pool exists (by name )and return it's Pool ID.
 func getPoolID(c *Config, resource_pool_name string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[getPoolID]\n")
 
 	if resource_pool_name == "/" || resource_pool_name == "Resources" {
@@ -36,7 +36,7 @@ func getPoolID(c *Config, resource_pool_name string) (string, error) {
 
 //  Check if Pool exists (by id)and return it's Pool name.
 func getPoolNAME(c *Config, resource_pool_id string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[getPoolNAME]\n")
 
 	var ResourcePoolName, fullResourcePoolName string
@@ -82,7 +82,7 @@ func getPoolNAME(c *Config, resource_pool_id string) (string, error) {
 }
 
 func resourcePoolRead(c *Config, pool_id string) (string, int, string, int, string, int, string, int, string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourcePoolRead]")
 
 	var remote_cmd, stdout, cpu_shares, mem_shares string

--- a/esxi/resource-pool_update.go
+++ b/esxi/resource-pool_update.go
@@ -2,15 +2,16 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceRESOURCEPOOLUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceRESOURCEPOOLUpdate]")
 
 	var remote_cmd, stdout string
@@ -41,7 +42,7 @@ func resourceRESOURCEPOOLUpdate(d *schema.ResourceData, m interface{}) error {
 	if stdout != resource_pool_name {
 		log.Printf("[resourceRESOURCEPOOLUpdate] rename %s %s", pool_id, resource_pool_name)
 		remote_cmd = fmt.Sprintf("vim-cmd hostsvc/rsrc/rename %s %s", pool_id, resource_pool_name)
-		stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "update resource pool")
+		stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "update resource pool")
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,7 @@ func resourceRESOURCEPOOLUpdate(d *schema.ResourceData, m interface{}) error {
 		cpu_min_opt, cpu_min_expandable_opt, cpu_max_opt, cpu_shares_opt,
 		mem_min_opt, mem_min_expandable_opt, mem_max_opt, mem_shares_opt, pool_id)
 
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "update resource pool")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "update resource pool")
 	log.Printf("[resourcePoolUPDATE] stdout |%s|\n", stdout)
 
 	r := strings.NewReplacer("'vim.ResourcePool:", "", "'", "")

--- a/esxi/resource-pool_update.go
+++ b/esxi/resource-pool_update.go
@@ -11,7 +11,7 @@ import (
 
 func resourceRESOURCEPOOLUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourceRESOURCEPOOLUpdate]")
 
 	var remote_cmd, stdout string

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -3,11 +3,12 @@ package esxi
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"log"
 	"net/url"
 	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceGUEST() *schema.Resource {
@@ -276,7 +277,7 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 
 	if clone_from_vm != "" {
 		password := url.QueryEscape(c.esxiPassword)
-		src_path = fmt.Sprintf("vi://%s:%s@%s/%s", c.esxiUserName, password, c.esxiHostName, clone_from_vm)
+		src_path = fmt.Sprintf("vi://%s:%s@%s:%s/%s", c.esxiUserName, password, c.esxiHostName, c.esxiHostSSLport, clone_from_vm)
 	} else if ovf_source != "" {
 		src_path = ovf_source
 	} else {

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -28,6 +28,13 @@ func resourceGUEST() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("clone_from_vm", nil),
 				Description: "Source vm path on esxi host to clone.",
 			},
+			"host_ovf": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("host_ovf", nil),
+				Description: "Path on exsi host of ovf files.",
+			},
 			"ovf_source": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/esxi/virtual-disk_create.go
+++ b/esxi/virtual-disk_create.go
@@ -2,15 +2,16 @@ package esxi
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceVIRTUALDISKCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	//esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	//esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceVIRTUALDISKCreate]")
 
 	virtual_disk_disk_store := d.Get("virtual_disk_disk_store").(string)

--- a/esxi/virtual-disk_delete.go
+++ b/esxi/virtual-disk_delete.go
@@ -10,7 +10,7 @@ import (
 
 func resourceVIRTUALDISKDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[resourceVIRTUALDISKDelete]")
 
 	var remote_cmd, stdout string

--- a/esxi/virtual-disk_functions.go
+++ b/esxi/virtual-disk_functions.go
@@ -12,7 +12,7 @@ import (
 //  Validate Disk Store
 //
 func diskStoreValidate(c *Config, disk_store string) error {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[diskStoreValidate]\n")
 
 	var remote_cmd, stdout string
@@ -51,7 +51,7 @@ func diskStoreValidate(c *Config, disk_store string) error {
 //
 func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_dir string,
 	virtual_disk_name string, virtual_disk_size int, virtual_disk_type string) (string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[virtualDiskCREATE]")
 
 	var virtdisk_id, remote_cmd string
@@ -106,7 +106,7 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 //  Grow virtual Disk
 //
 func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[growVirtualDisk]\n")
 
 	var newDiskSize int
@@ -132,7 +132,7 @@ func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error 
 //  Read virtual Disk details
 //
 func virtualDiskREAD(c *Config, virtdisk_id string) (string, string, string, int, string, error) {
-	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[virtualDiskREAD] Begin")
 
 	var virtual_disk_disk_store, virtual_disk_dir, virtual_disk_name string

--- a/esxi/virtual-disk_functions.go
+++ b/esxi/virtual-disk_functions.go
@@ -12,7 +12,7 @@ import (
 //  Validate Disk Store
 //
 func diskStoreValidate(c *Config, disk_store string) error {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Printf("[diskStoreValidate]\n")
 
 	var remote_cmd, stdout string
@@ -22,7 +22,7 @@ func diskStoreValidate(c *Config, disk_store string) error {
 	//  Check if Disk Store already exists
 	//
 	remote_cmd = fmt.Sprintf("esxcli storage filesystem list | grep '/vmfs/volumes/.*[VMFS|NFS]' |awk '{for(i=2;i<=NF-5;++i)printf $i\" \" ; printf \"\\n\"}'")
-	stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get list of disk stores")
+	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get list of disk stores")
 	if err != nil {
 		return fmt.Errorf("Unable to get list of disk stores: %s\n", err)
 	}
@@ -30,10 +30,10 @@ func diskStoreValidate(c *Config, disk_store string) error {
 
 	if strings.Contains(stdout, disk_store) == false {
 		remote_cmd = fmt.Sprintf("esxcli storage filesystem rescan")
-		_, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Refresh filesystems")
+		_, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Refresh filesystems")
 
 		remote_cmd = fmt.Sprintf("esxcli storage filesystem list | grep '/vmfs/volumes/.*[VMFS|NFS]' |awk '{for(i=2;i<=NF-5;++i)printf $i\" \" ; printf \"\\n\"}'")
-		stdout, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get list of disk stores")
+		stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get list of disk stores")
 		if err != nil {
 			return fmt.Errorf("Unable to get list of disk stores: %s\n", err)
 		}
@@ -51,7 +51,7 @@ func diskStoreValidate(c *Config, disk_store string) error {
 //
 func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_dir string,
 	virtual_disk_name string, virtual_disk_size int, virtual_disk_type string) (string, error) {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[virtualDiskCREATE]")
 
 	var virtdisk_id, remote_cmd string
@@ -69,10 +69,10 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 	//  Create dir if required
 	//
 	remote_cmd = fmt.Sprintf("mkdir -p \"/vmfs/volumes/%s/%s\"", virtual_disk_disk_store, virtual_disk_dir)
-	_, _ = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "create virtual disk dir")
+	_, _ = runRemoteSshCommand(esxiConnInfo, remote_cmd, "create virtual disk dir")
 
 	remote_cmd = fmt.Sprintf("ls -d \"/vmfs/volumes/%s/%s\"", virtual_disk_disk_store, virtual_disk_dir)
-	_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "validate dir exists")
+	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "validate dir exists")
 	if err != nil {
 		return "", errors.New("Unable to create virtual_disk directory.")
 	}
@@ -86,7 +86,7 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 	//  Validate if it exists already
 	//
 	remote_cmd = fmt.Sprintf("ls -l \"%s\"", virtdisk_id)
-	_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "validate disk store exists")
+	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "validate disk store exists")
 	if err == nil {
 		log.Println("[virtualDiskCREATE]  Already exists.")
 		return virtdisk_id, err
@@ -94,7 +94,7 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 
 	remote_cmd = fmt.Sprintf("/bin/vmkfstools -c %dG -d %s \"%s\"", virtual_disk_size,
 		virtual_disk_type, virtdisk_id)
-	_, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Create virtual_disk")
+	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Create virtual_disk")
 	if err != nil {
 		return "", errors.New("Unable to create virtual_disk")
 	}
@@ -106,7 +106,7 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 //  Grow virtual Disk
 //
 func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Printf("[growVirtualDisk]\n")
 
 	var newDiskSize int
@@ -119,7 +119,7 @@ func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error 
 
 	if currentDiskSize < newDiskSize {
 		remote_cmd := fmt.Sprintf("/bin/vmkfstools -X %dG \"%s\"", newDiskSize, virtdisk_id)
-		_, err := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "grow disk")
+		_, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "grow disk")
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error 
 //  Read virtual Disk details
 //
 func virtualDiskREAD(c *Config, virtdisk_id string) (string, string, string, int, string, error) {
-	esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostSSHport, c.esxiHostSSLport, c.esxiUserName, c.esxiPassword}
 	log.Println("[virtualDiskREAD] Begin")
 
 	var virtual_disk_disk_store, virtual_disk_dir, virtual_disk_name string
@@ -153,7 +153,7 @@ func virtualDiskREAD(c *Config, virtdisk_id string) (string, string, string, int
 
 	// Test if virtual disk exists
 	remote_cmd := fmt.Sprintf("test -s \"%s\"", virtdisk_id)
-	_, err := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "test if virtual disk exists")
+	_, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "test if virtual disk exists")
 	if err != nil {
 		return "", "", "", 0, "", err
 	}
@@ -167,7 +167,7 @@ func virtualDiskREAD(c *Config, virtdisk_id string) (string, string, string, int
 
 	remote_cmd = fmt.Sprintf("ls -l \"/vmfs/volumes/%s/%s/%s\" | awk '{print $5}'",
 		virtual_disk_disk_store, virtual_disk_dir, virtual_disk_nameFlat)
-	flatSize, err = runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get size")
+	flatSize, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get size")
 	if err != nil {
 		return "", "", "", 0, "", err
 	}
@@ -176,13 +176,13 @@ func virtualDiskREAD(c *Config, virtdisk_id string) (string, string, string, int
 
 	// Determine virtual disk type  (only works if Guest is powered off)
 	remote_cmd = fmt.Sprintf("vmkfstools -t0 \"%s\" |grep -q 'VMFS Z- LVID:' && echo true", virtdisk_id)
-	isZeroedThick, _ := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get disk type.  Is zeroedthick.")
+	isZeroedThick, _ := runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get disk type.  Is zeroedthick.")
 
 	remote_cmd = fmt.Sprintf("vmkfstools -t0 \"%s\" |grep -q 'VMFS -- LVID:' && echo true", virtdisk_id)
-	isEagerZeroedThick, _ := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get disk type.  Is eagerzeroedthick.")
+	isEagerZeroedThick, _ := runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get disk type.  Is eagerzeroedthick.")
 
 	remote_cmd = fmt.Sprintf("vmkfstools -t0 \"%s\" |grep -q 'NOMP -- :' && echo true", virtdisk_id)
-	isThin, _ := runRemoteSshCommand(esxiSSHinfo, remote_cmd, "Get disk type.  Is thin.")
+	isThin, _ := runRemoteSshCommand(esxiConnInfo, remote_cmd, "Get disk type.  Is thin.")
 
 	if isThin == "true" {
 		virtual_disk_type = "thin"

--- a/esxi/virtual-disk_update.go
+++ b/esxi/virtual-disk_update.go
@@ -2,14 +2,15 @@ package esxi
 
 import (
 	"errors"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceVIRTUALDISKUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
-	//esxiSSHinfo := SshConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
+	//esxiConnInfo := ConnectionStruct{c.esxiHostName, c.esxiHostPort, c.esxiUserName, c.esxiPassword}
 	log.Println("[resourceVIRTUALDISKUpdate]")
 
 	if d.HasChange("virtual_disk_size") {

--- a/examples-legacy/01 Simple Guest/main.tf
+++ b/examples-legacy/01 Simple Guest/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname  = "${var.esxi_hostname}"
   esxi_hostport  = "${var.esxi_hostport}"
+  esxi_hostssl   = "${var.esxi_hostssl}"
   esxi_username  = "${var.esxi_username}"
   esxi_password  = "${var.esxi_password}"
 }

--- a/examples-legacy/01 Simple Guest/variables.tf
+++ b/examples-legacy/01 Simple Guest/variables.tf
@@ -6,5 +6,6 @@
 
 variable "esxi_hostname" { default = "esxi" }
 variable "esxi_hostport" { default = "22" }
+variable "esxi_hostssl" { default = "443" }
 variable "esxi_username" { default = "root" }
 variable "esxi_password" { } # Unspecified will prompt

--- a/examples-legacy/02 Cloned Guest - Complete build/main.tf
+++ b/examples-legacy/02 Cloned Guest - Complete build/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname  = "${var.esxi_hostname}"
   esxi_hostport  = "${var.esxi_hostport}"
+  esxi_hostssl  = "${var.esxi_hostssl}"
   esxi_username  = "${var.esxi_username}"
   esxi_password  = "${var.esxi_password}"
 }

--- a/examples-legacy/02 Cloned Guest - Complete build/variables.tf
+++ b/examples-legacy/02 Cloned Guest - Complete build/variables.tf
@@ -6,5 +6,6 @@
 
 variable "esxi_hostname" { default = "esxi" }
 variable "esxi_hostport" { default = "22" }
+variable "esxi_hostssl" { default = "443" }
 variable "esxi_username" { default = "root" }
 variable "esxi_password" { } # Unspecified will prompt

--- a/examples-legacy/03 Resource Pools - Additional Storage/main.tf
+++ b/examples-legacy/03 Resource Pools - Additional Storage/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname  = "${var.esxi_hostname}"
   esxi_hostport  = "${var.esxi_hostport}"
+  esxi_hostssl   = "${var.esxi_hostssl}"
   esxi_username  = "${var.esxi_username}"
   esxi_password  = "${var.esxi_password}"
 }

--- a/examples-legacy/03 Resource Pools - Additional Storage/variables.tf
+++ b/examples-legacy/03 Resource Pools - Additional Storage/variables.tf
@@ -6,6 +6,7 @@
 
 variable "esxi_hostname" { default = "esxi" }
 variable "esxi_hostport" { default = "22" }
+variable "esxi_hostssl" { default = "443" }
 variable "esxi_username" { default = "root" }
 variable "esxi_password" { } # Unspecified will prompt
 

--- a/examples-legacy/04 CoreOS and Ignition/main.tf
+++ b/examples-legacy/04 CoreOS and Ignition/main.tf
@@ -8,6 +8,7 @@ provider "esxi" {
   version       = "~> 1.3"
   esxi_hostname = "${var.esxi_hostname}"
   esxi_hostport = "${var.esxi_hostport}"
+  esxi_hostssl  = "${var.esxi_hostssl}"
   esxi_username = "${var.esxi_username}"
   esxi_password = "${var.esxi_password}"
 }

--- a/examples-legacy/04 CoreOS and Ignition/variables.tf
+++ b/examples-legacy/04 CoreOS and Ignition/variables.tf
@@ -10,6 +10,9 @@ variable "esxi_hostname" {
 variable "esxi_hostport" {
   default = "22"
 }
+variable "esxi_hostssl" {
+  default = "443"
+}
 variable "esxi_username" {
   default = "root"
 }

--- a/examples-legacy/05 CloudInit and Templates/main.tf
+++ b/examples-legacy/05 CloudInit and Templates/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname  = "${var.esxi_hostname}"
   esxi_hostport  = "${var.esxi_hostport}"
+  esxi_hostssl   = "${var.esxi_hostssl}"
   esxi_username  = "${var.esxi_username}"
   esxi_password  = "${var.esxi_password}"
 }

--- a/examples-legacy/05 CloudInit and Templates/variables.tf
+++ b/examples-legacy/05 CloudInit and Templates/variables.tf
@@ -10,6 +10,9 @@ variable "esxi_hostname" {
 variable "esxi_hostport" {
   default = "22"
 }
+variable "esxi_hostssl" {
+  default = "443"
+}
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/01 Simple Guest/main.tf
+++ b/examples/01 Simple Guest/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname = var.esxi_hostname
   esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.exsi_hostssl
   esxi_username = var.esxi_username
   esxi_password = var.esxi_password
 }

--- a/examples/01 Simple Guest/variables.tf
+++ b/examples/01 Simple Guest/variables.tf
@@ -12,6 +12,10 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+variable "esxi_hostssl" {
+  default = "443"
+}
+
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/02 Cloned Guest - Complete build/main.tf
+++ b/examples/02 Cloned Guest - Complete build/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname = var.esxi_hostname
   esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.esxi_hostssl
   esxi_username = var.esxi_username
   esxi_password = var.esxi_password
 }

--- a/examples/02 Cloned Guest - Complete build/variables.tf
+++ b/examples/02 Cloned Guest - Complete build/variables.tf
@@ -12,6 +12,10 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+variable "esxi_hostssl" {
+  default = "443"
+}
+
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/03 Resource Pools - Additional Storage/main.tf
+++ b/examples/03 Resource Pools - Additional Storage/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname = var.esxi_hostname
   esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.esxi_hostssl
   esxi_username = var.esxi_username
   esxi_password = var.esxi_password
 }

--- a/examples/03 Resource Pools - Additional Storage/variables.tf
+++ b/examples/03 Resource Pools - Additional Storage/variables.tf
@@ -12,6 +12,11 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+variable "esxi_hostssl" {
+  default = "443"
+}
+
+
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/04 CoreOS and Ignition/main.tf
+++ b/examples/04 CoreOS and Ignition/main.tf
@@ -8,6 +8,7 @@ provider "esxi" {
   version       = "~> 1.5"
   esxi_hostname = var.esxi_hostname
   esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.esxi_hostssl
   esxi_username = var.esxi_username
   esxi_password = var.esxi_password
 }

--- a/examples/04 CoreOS and Ignition/variables.tf
+++ b/examples/04 CoreOS and Ignition/variables.tf
@@ -12,6 +12,10 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+variable "esxi_hostssl" {
+  default = "443"
+}
+
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/05 CloudInit and Templates/main.tf
+++ b/examples/05 CloudInit and Templates/main.tf
@@ -7,6 +7,7 @@
 provider "esxi" {
   esxi_hostname = var.esxi_hostname
   esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.esxi_hostssl
   esxi_username = var.esxi_username
   esxi_password = var.esxi_password
 }

--- a/examples/05 CloudInit and Templates/variables.tf
+++ b/examples/05 CloudInit and Templates/variables.tf
@@ -12,6 +12,10 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+variable "esxi_hostssl" {
+  default = "443"
+}
+
 variable "esxi_username" {
   default = "root"
 }

--- a/examples/06 OVF Properties/main.tf
+++ b/examples/06 OVF Properties/main.tf
@@ -1,6 +1,7 @@
 provider "esxi" {
   esxi_hostname      = var.esxi_hostname
   esxi_hostport      = var.esxi_hostport
+  esxi_hostssl       = var.esxi_hostssl
   esxi_username      = var.esxi_username
   esxi_password      = var.esxi_password
 }

--- a/examples/06 OVF Properties/variables.tf
+++ b/examples/06 OVF Properties/variables.tf
@@ -12,6 +12,10 @@ variable "esxi_hostport" {
   default = "22"
 }
 
+varaible "esxi_hostssl" {
+  default = "443"
+}
+
 variable "esxi_username" {
   default = "root"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/josenk/terraform-provider-esxi
 
-go 1.14
-
 require (
 	github.com/hashicorp/terraform v0.12.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/josenk/terraform-provider-esxi
 
+go 1.14
+
 require (
 	github.com/hashicorp/terraform v0.12.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect


### PR DESCRIPTION
Fix for #111

- _Updated_ documentation and examples to reflect the change.
- _Added_ `esxi_hostssl` to provider, with default value of "443".

### Likely to be breaking changes for any unmerged PRs:

- _Renamed_ `esxiSSHinfo` to `esxiConnInfo` (to reflect that it's about more than SSH.)
- _Renamed_ `esxiHostPort` to `esxiHostSSHport` in `Config`.
- _Added_ `esxiHostSSLport` to `Config`.
