### PR TITLE
Manage the portgroup security policy

### DIFF
--- a/esxi/portgroup_create.go
+++ b/esxi/portgroup_create.go
@@ -13,13 +13,11 @@ func resourcePORTGROUPCreate(d *schema.ResourceData, m interface{}) error {
 	log.Println("[resourcePORTGROUPCreate]")
 
 	var stdout string
-	var somthingWentWrong string
 	var remote_cmd string
 	var err error
 
 	name := d.Get("name").(string)
 	vswitch := d.Get("vswitch").(string)
-	vlan := d.Get("vlan").(int)
 
 	//  Create PORTGROUP
 	remote_cmd = fmt.Sprintf("esxcli network vswitch standard portgroup add -v \"%s\" -p \"%s\"",
@@ -34,27 +32,5 @@ func resourcePORTGROUPCreate(d *schema.ResourceData, m interface{}) error {
 	//  Set id
 	d.SetId(name)
 
-	//  set vlan id
-	remote_cmd = fmt.Sprintf("esxcli network vswitch standard portgroup set -v \"%d\" -p \"%s\"",
-		vlan, name)
-
-	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "portgroup set vlan")
-	if err != nil {
-		somthingWentWrong = fmt.Sprintf("Failed to set portgroup vlan: %s\n%s\n", stdout, err)
-	}
-
-	// Refresh
-	vswitch, vlan, err = portgroupRead(c, name)
-	if err != nil {
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("vswitch", vswitch)
-	d.Set("vlan", vlan)
-
-	if somthingWentWrong != "" {
-		return fmt.Errorf(somthingWentWrong)
-	}
-	return nil
+	return resourcePORTGROUPUpdate(d, m)
 }

--- a/esxi/portgroup_functions.go
+++ b/esxi/portgroup_functions.go
@@ -6,7 +6,15 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/jszwec/csvutil"
 )
+
+type portgroupSecurityPolicy struct {
+	AllowForgedTransmits  bool `csv:"AllowForgedTransmits"`
+	AllowMACAddressChange bool `csv:"AllowMACAddressChange"`
+	AllowPromiscuous      bool `csv:"AllowPromiscuous"`
+}
 
 func portgroupRead(c *Config, name string) (string, int, error) {
 	esxiConnInfo := getConnectionInfo(c)
@@ -39,4 +47,21 @@ func portgroupRead(c *Config, name string) (string, int, error) {
 	}
 
 	return vswitch, vlan, nil
+}
+
+func portgroupSecurityPolicyRead(c *Config, name string) (*portgroupSecurityPolicy, error) {
+	esxiConnInfo := getConnectionInfo(c)
+
+	remote_cmd := fmt.Sprintf("esxcli --formatter=csv network vswitch standard portgroup policy security get -p \"%s\"", name)
+	stdout, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "portgroup security policy")
+	if stdout == "" {
+		return nil, fmt.Errorf("Failed to get the portgroup security policy: %s\n%s\n", stdout, err)
+	}
+
+	var policies []portgroupSecurityPolicy
+	if err = csvutil.Unmarshal([]byte(stdout), &policies); err != nil || len(policies) != 1 {
+		return nil, fmt.Errorf("Failed to parse the portgroup security policy: %s\n%s\n", stdout, err)
+	}
+
+	return &policies[0], nil
 }

--- a/esxi/portgroup_import.go
+++ b/esxi/portgroup_import.go
@@ -29,5 +29,7 @@ func resourcePORTGROUPImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	}
 
 	d.SetId(d.Id())
+	d.Set("name", d.Id())
+
 	return results, nil
 }

--- a/esxi/portgroup_read.go
+++ b/esxi/portgroup_read.go
@@ -27,5 +27,13 @@ func resourcePORTGROUPRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("vswitch", vswitch)
 	d.Set("vlan", vlan)
 
+	policy, err := portgroupSecurityPolicyRead(c, name)
+	if err != nil {
+		return err
+	}
+	d.Set("promiscuous_mode", policy.AllowPromiscuous)
+	d.Set("mac_changes", policy.AllowMACAddressChange)
+	d.Set("forged_transmits", policy.AllowForgedTransmits)
+
 	return nil
 }

--- a/esxi/resource_portgroup.go
+++ b/esxi/resource_portgroup.go
@@ -37,6 +37,27 @@ func resourcePORTGROUP() *schema.Resource {
 				Description:  "portgroup vlan.",
 				ValidateFunc: validation.IntBetween(0, 4095),
 			},
+			"promiscuous_mode": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Default:     false,
+				Description: "Promiscuous mode (true=Accept/false=Reject).",
+			},
+			"mac_changes": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Default:     false,
+				Description: "MAC address changes (true=Accept/false=Reject).",
+			},
+			"forged_transmits": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    false,
+				Default:     false,
+				Description: "Forged transmits (true=Accept/false=Reject).",
+			},
 		},
 	}
 }

--- a/esxi/vswitch_import.go
+++ b/esxi/vswitch_import.go
@@ -29,5 +29,7 @@ func resourceVSWITCHImport(d *schema.ResourceData, m interface{}) ([]*schema.Res
 	}
 
 	d.SetId(d.Id())
+	d.Set("name", d.Id())
+
 	return results, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/josenk/terraform-provider-esxi
 
 require (
 	github.com/hashicorp/terraform v0.12.2
+	github.com/jszwec/csvutil v1.5.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/tmc/scp v0.0.0-20170824174625-f7b48647feef
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734


### PR DESCRIPTION
This lets us manage the portgroup security policy.

The port group security policy also supports a 3rd state of "Inherit from vSwitch", but I'm not adding support for that. Even though `esxcli` allows us to inherit each value independently, the ESXi UI will not correctly display/edit the settings, which will confuse the Human operator, so I just ignored that and this will always set the values.

Please note that this also includes https://github.com/josenk/terraform-provider-esxi/pull/152.