### PR TITLE
[feature] support multiple ovf_network mapping, enhance/fix upstream issue #103

### DIFF
--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -18,7 +18,7 @@ import (
 
 func guestCREATE(c *Config, guest_name string, disk_store string,
 	src_path string, resource_pool_name string, strmemsize string, strnumvcpus string, strvirthwver string, guestos string,
-	boot_disk_type string, boot_disk_size string, virtual_networks [10][3]string,
+	boot_disk_type string, boot_disk_size string, virtual_networks [10][4]string,
 	virtual_disks [60][2]string, guest_shutdown_timeout int, ovf_properties_timer int, notes string,
 	guestinfo map[string]interface{}, ovf_properties map[string]string) (string, error) {
 
@@ -227,7 +227,19 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 
 		net_param := ""
 		if (strings.HasSuffix(src_path, ".ova") || strings.HasSuffix(src_path, ".ovf")) && virtual_networks[0][0] != "" {
-			net_param = " --network='" + virtual_networks[0][0] + "'"
+			// if ovf_network is set (not emptied), then we will add --net to net_param for ovf network mapping
+			// if ovt_network is emptied, then we will just resume to the default --network creation
+			log.Printf("[guestCREATE] Detecting single --network or multiple --net...\n")
+			if virtual_networks[0][3] == "" {
+				net_param += " --network='" + virtual_networks[0][0] + "'"
+			}
+
+			for i := 0; i < 10; i++ {
+				if virtual_networks[i][3] != "" {
+					net_param += " --net:'" + virtual_networks[i][3] + "=" + virtual_networks[i][0] + "'"
+				}
+			}
+			log.Printf("[guestCREATE] net_param: %s\n", net_param)
 		}
 
 		extra_params := ""

--- a/esxi/guest-read.go
+++ b/esxi/guest-read.go
@@ -57,6 +57,7 @@ func resourceGUESTRead(d *schema.ResourceData, m interface{}) error {
 			out["virtual_network"] = virtual_networks[nic][0]
 			out["mac_address"] = virtual_networks[nic][1]
 			out["nic_type"] = virtual_networks[nic][2]
+			out["ovf_network"] = virtual_networks[nic][3]
 			nics = append(nics, out)
 		}
 	}
@@ -83,7 +84,7 @@ func resourceGUESTRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, string, string, string, string, string, string, string, string, string, [10][3]string, [60][2]string, string, string, map[string]interface{}, error) {
+func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, string, string, string, string, string, string, string, string, string, [10][4]string, [60][2]string, string, string, map[string]interface{}, error) {
 	esxiConnInfo := getConnectionInfo(c)
 	log.Println("[guestREAD]")
 
@@ -91,7 +92,7 @@ func guestREAD(c *Config, vmid string, guest_startup_timeout int) (string, strin
 	var dst_vmx_ds, dst_vmx, dst_vmx_file, vmx_contents, power string
 	var disk_size, vdiskindex int
 	var memsize, numvcpus, virthwver string
-	var virtual_networks [10][3]string
+	var virtual_networks [10][4]string
 	var virtual_disks [60][2]string
 	var guestinfo map[string]interface{}
 

--- a/esxi/guest_functions.go
+++ b/esxi/guest_functions.go
@@ -102,7 +102,7 @@ func readVmx_contents(c *Config, vmid string) (string, error) {
 }
 
 func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numvcpus int,
-	virthwver int, guestos string, virtual_networks [10][3]string, virtual_disks [60][2]string, notes string,
+	virthwver int, guestos string, virtual_networks [10][4]string, virtual_disks [60][2]string, notes string,
 	guestinfo map[string]interface{}) error {
 
 	esxiConnInfo := getConnectionInfo(c)

--- a/esxi/guest_update.go
+++ b/esxi/guest_update.go
@@ -13,7 +13,7 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	c := m.(*Config)
 	log.Printf("[resourceGUESTUpdate]\n")
 
-	var virtual_networks [10][3]string
+	var virtual_networks [10][4]string
 	var virtual_disks [60][2]string
 	var i int
 	var err error
@@ -48,6 +48,9 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 		if attr, ok := d.Get(prefix + "nic_type").(string); ok && attr != "" {
 			virtual_networks[i][2] = d.Get(prefix + "nic_type").(string)
+		}
+		if attr, ok := d.Get(prefix + "ovf_network").(string); ok && attr != "" {
+			virtual_networks[i][3] = d.Get(prefix + "ovf_network").(string)
 		}
 	}
 

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -129,6 +129,12 @@ func resourceGUEST() *schema.Resource {
 							ForceNew: false,
 							Computed: true,
 						},
+						"ovf_network": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -231,7 +237,7 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[resourceGUESTCreate]\n")
 
-	var virtual_networks [10][3]string
+	var virtual_networks [10][4]string
 	var virtual_disks [60][2]string
 	var src_path string
 	var tmpint, i, virtualDiskCount, ovfPropsCount, guest_shutdown_timeout, ovf_properties_timer int
@@ -343,6 +349,10 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 				errMSG := fmt.Sprintf("Error: invalid nic_type. %s\nMust be vlance flexible e1000 e1000e vmxnet vmxnet2 or vmxnet3", virtual_networks[i][2])
 				return errors.New(errMSG)
 			}
+		}
+
+		if attr, ok := d.Get(prefix + "ovf_network").(string); ok && attr != "" {
+			virtual_networks[i][3] = d.Get(prefix + "ovf_network").(string)
 		}
 	}
 


### PR DESCRIPTION
This PR created from my actual use-cases involved multiple ovf network interfaces already defined in a signed ova file (by other).

Feature:
- Supports both single --network and/or multiple --net for network_interfaces creation with ova/ovf sources.  So multiple network interfaces already defined in ova/ovf source file will not raise error anymore.
- Before the changes, you have to extract ovf file from ova source and manually change to only single network interface and then re-package that ova file - which will not work if you have to deal with signed ova file.
- Please see original issue: https://github.com/josenk/terraform-provider-esxi/issues/103

The changes should work with any variations or orders of the following declaration:
```conf
  network_interfaces {
    virtual_network = "VM Network"
    nic_type        = "vmxnet3"
    ovf_network     = "WAN"
  }

  network_interfaces {
    virtual_network = "VyOS VLAN 10"
    nic_type        = "vmxnet3"
    ovf_network     = "LAN"
  }

  network_interfaces {
    virtual_network = "VyOS VLAN 20"
    nic_type        = "vmxnet3"
  }
```

In the above example, the ova source file defined 2 default ovf network interfaces (WAN and LAN), therefore ```--net:'WAN=VM Network' --net:'LAN=VM Network'``` will be generated as new 'net_param'.  Without these changes, you will see the error message "OVFtool error: No network mapping specified".

Support 'net_param' style:
- ovf network mapping: --net:'WAN=VM Network' --net:'LAN=VM Network'
- default style: --network='VM Network'
- mixed: --network='VyOS VLAN 20' --net:'WAN=VM Network' --net:'LAN=VyOS VLAN 10'

Test case 1:
- Create with the above example
- Add/update
``` conf
  network_interfaces {
    virtual_network = "VyOS VLAN 30"
    nic_type        = "vmxnet3"
  }

  network_interfaces {
    virtual_network = "VyOS VLAN 40"
    nic_type        = "vmxnet3"
  }
```
- Run terraform apply

Test case 2:
- Create with 1 single network
- Update with 2,3 more network interfces 
- Run terraform apply

Test case 3:
- Create with 4 mixed network interfces
- Delete 2 network interfaces
- Run terraform apply

Test case 4:
- Create with default (old) style single network
- Run terraform apply

Test case 5:
- Define multiple 'esxi_guest' with ovf_network and without ovf_network
- Run terraform apply

Please feel free to let me know should you need any changes/correction from this, I would be happy to revise accordingly.