### PR TITLE
[BUG] add CheckMACAddress to VMX file to prevent ESXi mac checking

### DIFF
--- a/esxi/guest_functions.go
+++ b/esxi/guest_functions.go
@@ -313,6 +313,9 @@ func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numv
 
 				tmpvar = fmt.Sprintf("ethernet%d.address = \"%s\"\n", i, virtual_networks[i][1])
 				vmx_contents_new = vmx_contents_new + tmpvar
+				
+				tmpvar = fmt.Sprintf("ethernet%d.CheckMACAddress = \"FALSE\"\n", i)
+				vmx_contents_new = vmx_contents_new + tmpvar
 			}
 
 			//  Set network type


### PR DESCRIPTION
This PR fix VM power on when mac_address is defined as described in https://github.com/josenk/terraform-provider-esxi/issues/166#issuecomment-1024546891