### PR TITLE
[add] pull upload mode on guest creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+go.sum
+terraform-provider-esxi_v*

--- a/esxi/config.go
+++ b/esxi/config.go
@@ -3,6 +3,7 @@ package esxi
 import (
 	"fmt"
 	"log"
+	"regexp"
 )
 
 type Config struct {
@@ -11,20 +12,24 @@ type Config struct {
 	esxiHostSSLport string
 	esxiUserName    string
 	esxiPassword    string
+	esxiVersion     string
 }
 
 func (c *Config) validateEsxiCreds() error {
 	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[validateEsxiCreds]\n")
 
-	var remote_cmd string
+	var remote_cmd, raw_esxi_version string
 	var err error
 
 	remote_cmd = fmt.Sprintf("vmware --version")
-	_, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Connectivity test, get vmware version")
+	raw_esxi_version, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "Connectivity test, get vmware version")
 	if err != nil {
 		return fmt.Errorf("Failed to connect to esxi host: %s\n", err)
 	}
+
+	re := regexp.MustCompile(`(\d{1,2}\.\d{1,2}\.\d{1,3})`)
+	c.esxiVersion = re.FindAllString(raw_esxi_version, -1)[0]
 
 	runRemoteSshCommand(esxiConnInfo, "mkdir -p ~", "Create home directory if missing")
 

--- a/esxi/portgroup_create.go
+++ b/esxi/portgroup_create.go
@@ -24,9 +24,17 @@ func resourcePORTGROUPCreate(d *schema.ResourceData, m interface{}) error {
 		vswitch, name)
 
 	stdout, err = runRemoteSshCommand(esxiConnInfo, remote_cmd, "create portgroup")
+
 	if err != nil {
-		d.SetId("")
-		return fmt.Errorf("Failed to add portgroup: %s\n%s\n", stdout, err)
+		// check if message on error is because a portgroup is already existing on host
+		var msg_already_exists string
+		msg_already_exists = fmt.Sprintf("A portgroup with the name %s already exists", name)
+		if stdout != msg_already_exists {
+			d.SetId("")
+			return fmt.Errorf("Failed to add portgroup: %s\n%s\n", stdout, err)
+		} else {
+			log.Printf("[resourcePORTGROUPCreate] %s - continuing\n", stdout)
+		}
 	}
 
 	//  Set id

--- a/esxi/provider.go
+++ b/esxi/provider.go
@@ -68,6 +68,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		esxiHostSSLport: d.Get("esxi_hostssl").(string),
 		esxiUserName:    d.Get("esxi_username").(string),
 		esxiPassword:    d.Get("esxi_password").(string),
+		esxiVersion:     "",
 	}
 
 	if err := config.validateEsxiCreds(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/josenk/terraform-provider-esxi
 
 require (
+	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/terraform v0.12.2
 	github.com/jszwec/csvutil v1.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect


### PR DESCRIPTION
the flag `--pullUploadMode` enables ESXi host download the image directly without download on terraform machine and send to it after.

This mode improves my provision time in 87%. I execute terraform through a VPN connection.

This flag depends that ESXi version >= 6.7 and OVFTool >= 4.4.1, so I did some version checks to avoid compatibility problems.