### PR TITLE
add info in using ovf_source & clone_from_vm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,11 @@ Using ovf_source & clone_from_vm
     * For example, Ubuntu cloud-images: https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64.ova
 * If neither is specified, then a bare-metal VM will be created.  There will be no OS on this vm.  If the VM is powered on, it will default to a network PXE boot.  
 * ovf_source & clone_from_vm are mutually exclusive.
+* List of available ovf properties can be seen by using ovftool.
+  * ovftool https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64.ova
+* Value for user-data ovf property should be base64-encoded string or file, for example.
+  * value = filebase64("${path.module}/user-data.yaml")
+* Examples for user-data settings can be found here: https://cloudinit.readthedocs.io/en/latest/topics/examples.html
 
 
 Known issues with vmware_esxi


### PR DESCRIPTION
There were some authentication issues while I tried to deploy Ubuntu 20.04.4 LTS (Focal Fossa) cloud image:
https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.ova

After deploy, a password for the default user "ubuntu" wasn't set, so I was unable to log in to the VM using ESXi console.

I ran ovftool to see which ovf properties are available:
```
Properties:
  Key:         instance-id
  Label:       A Unique Instance ID for this instance
  Type:        string
  Description: Specifies the instance id.  This is required and used to
               determine if the machine should take "first boot" actions
  Value:       id-ovf

  Key:         hostname
  Type:        string
  Description: Specifies the hostname for the appliance
  Value:       ubuntuguest

  Key:         seedfrom
  Label:       Url to seed instance data from
  Type:        string
  Description: This field is optional, but indicates that the instance should
               'seed' user-data and meta-data from the given url.  If set to
               'http://tinyurl.com/sm-' is given, meta-data will be pulled from
               http://tinyurl.com/sm-meta-data and user-data from
               http://tinyurl.com/sm-user-data.  Leave this empty if you do not
               want to seed from a url.

  Key:         public-keys
  Label:       ssh public keys
  Type:        string
  Description: This field is optional, but indicates that the instance should
               populate the default user's 'authorized_keys' with this value

  Key:         user-data
  Label:       Encoded user-data
  Type:        string
  Description: In order to fit into a xml attribute, this value is base64
               encoded . It will be decoded, and then processed normally as
               user-data.

  Key:         password
  Label:       Default User's password
  Type:        string
  Description: If set, the default user's password will be set to this value to
               allow password based login.  The password will be good for only
               a single login.  If set to the string 'RANDOM' then a random
               password will be generated, and written to the console.

```

The solution was to use "password" ovf property:
```
ovf_properties {
  key              = "password"
  value            = var.vm_password
}
```

After I applied the solution, I was able to log in to the VM using ESXi console but SSH password authentication is disabled by default.

The next step was to enable SSH password authentication by using "user-data" ovf property:
```
ovf_properties {
  key              = "user-data"
  value            = filebase64("${path.module}/user-data.yaml")
}
```

Contents of user-data.yaml file
```
# cloud-config
ssh_pwauth: True ## This line enables ssh password authentication
```

Therefore, I've decided to add some information to the "Using ovf_source & clone_from_vm" section in case other users face the same issues.