### PR TITLE
Reload a guest after a successful disk expansion during Update

### DIFF
--- a/esxi/guest-create.go
+++ b/esxi/guest-create.go
@@ -354,7 +354,7 @@ func guestCREATE(c *Config, guest_name string, disk_store string,
 	//
 	boot_disk_vmdkPATH, _ = getBootDiskPath(c, vmid)
 
-	err = growVirtualDisk(c, boot_disk_vmdkPATH, boot_disk_size)
+	_, err = growVirtualDisk(c, boot_disk_vmdkPATH, boot_disk_size)
 	if err != nil {
 		return vmid, fmt.Errorf("Failed to grow boot disk: %s\n", err)
 	}

--- a/esxi/guest_update.go
+++ b/esxi/guest_update.go
@@ -17,6 +17,7 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	var virtual_disks [60][2]string
 	var i int
 	var err error
+	var did_grow bool
 
 	vmid := d.Id()
 	memsize := d.Get("memsize").(string)
@@ -104,9 +105,13 @@ func resourceGUESTUpdate(d *schema.ResourceData, m interface{}) error {
 	//
 	boot_disk_vmdkPATH, _ := getBootDiskPath(c, vmid)
 
-	err = growVirtualDisk(c, boot_disk_vmdkPATH, boot_disk_size)
+	did_grow, err = growVirtualDisk(c, boot_disk_vmdkPATH, boot_disk_size)
 	if err != nil {
 		return fmt.Errorf("Failed to grow virtual disk: %s\n", err)
+	}
+
+	if did_grow {
+		err = guestReload(c, vmid)
 	}
 
 	//  power on

--- a/esxi/virtual-disk_functions.go
+++ b/esxi/virtual-disk_functions.go
@@ -105,10 +105,11 @@ func virtualDiskCREATE(c *Config, virtual_disk_disk_store string, virtual_disk_d
 //
 //  Grow virtual Disk
 //
-func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error {
+func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) (bool, error) {
 	esxiConnInfo := getConnectionInfo(c)
 	log.Printf("[growVirtualDisk]\n")
 
+	var didGrowDisk bool
 	var newDiskSize int
 
 	_, _, _, currentDiskSize, _, err := virtualDiskREAD(c, virtdisk_id)
@@ -121,11 +122,12 @@ func growVirtualDisk(c *Config, virtdisk_id string, virtdisk_size string) error 
 		remote_cmd := fmt.Sprintf("/bin/vmkfstools -X %dG \"%s\"", newDiskSize, virtdisk_id)
 		_, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "grow disk")
 		if err != nil {
-			return err
+			return didGrowDisk, err
 		}
+		didGrowDisk = true
 	}
 
-	return err
+	return didGrowDisk, err
 }
 
 //

--- a/esxi/virtual-disk_update.go
+++ b/esxi/virtual-disk_update.go
@@ -27,7 +27,7 @@ func resourceVIRTUALDISKUpdate(d *schema.ResourceData, m interface{}) error {
 			return errors.New("Not able to shrink virtual disk:" + d.Id())
 		}
 
-		err = growVirtualDisk(c, d.Id(), strconv.Itoa(virtual_disk_size))
+		_, err = growVirtualDisk(c, d.Id(), strconv.Itoa(virtual_disk_size))
 		if err != nil {
 			return fmt.Errorf("Failed to grow virtual disk: %s\n", err)
 		}


### PR DESCRIPTION
When growing an existing guest's virtual disk, the ESXi web interface is not updated to show the correct storage capacity. This only happens on **update** operations and not **create** operations because create eventually reloads the guest (`vim-cmd vmsvc/reload`).

Note: This bug does not directly impact resources using the provider because the disk size is determined directly.

This does 2 things:
- Creates a `guestReload` function (similar to `guestPowerOn`), and refactors existing code to use it
- Calls `guestReload` when a guest disk is successfully expanded after `growVirtualDisk`