### PR TITLE
Add support for running ovftool directly on ESXi 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+go.sum
+
+

--- a/esxi/config.go
+++ b/esxi/config.go
@@ -11,6 +11,8 @@ type Config struct {
 	esxiHostSSLport string
 	esxiUserName    string
 	esxiPassword    string
+
+	esxiRemoteOvfToolPath string
 }
 
 func (c *Config) validateEsxiCreds() error {
@@ -27,6 +29,16 @@ func (c *Config) validateEsxiCreds() error {
 	}
 
 	runRemoteSshCommand(esxiConnInfo, "mkdir -p ~", "Create home directory if missing")
+
+	if c.esxiRemoteOvfToolPath != "" {
+		remote_cmd = fmt.Sprintf("%s --version", c.esxiRemoteOvfToolPath)
+		vsn, err := runRemoteSshCommand(esxiConnInfo, remote_cmd, "Checking installation of ovftool on ESXi")
+		if err != nil {
+			return fmt.Errorf("Failed to invoke ovftool on ESXi host: %+v\n", err)
+		}
+
+		log.Printf("Found ovftool on ESXi host: %s\n", vsn)
+	}
 
 	return nil
 }

--- a/esxi/provider.go
+++ b/esxi/provider.go
@@ -39,6 +39,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("esxi_password", "unset"),
 				Description: "esxi ssh password.",
 			},
+			"esxi_remote_ovftool_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ovftool path on ESXi host",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"esxi_guest":         resourceGUEST(),
@@ -53,11 +58,12 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		esxiHostName:    d.Get("esxi_hostname").(string),
-		esxiHostSSHport: d.Get("esxi_hostport").(string),
-		esxiHostSSLport: d.Get("esxi_hostssl").(string),
-		esxiUserName:    d.Get("esxi_username").(string),
-		esxiPassword:    d.Get("esxi_password").(string),
+		esxiHostName:          d.Get("esxi_hostname").(string),
+		esxiHostSSHport:       d.Get("esxi_hostport").(string),
+		esxiHostSSLport:       d.Get("esxi_hostssl").(string),
+		esxiUserName:          d.Get("esxi_username").(string),
+		esxiPassword:          d.Get("esxi_password").(string),
+		esxiRemoteOvfToolPath: d.Get("esxi_remote_ovftool_path").(string),
 	}
 
 	if err := config.validateEsxiCreds(); err != nil {

--- a/esxi/provider.go
+++ b/esxi/provider.go
@@ -1,19 +1,9 @@
 package esxi
 
 import (
-	"fmt"
-	"log"
-	"os"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
-
-func init() {
-	// Terraform is already adding the timestamp for us
-	log.SetFlags(log.Lshortfile)
-	log.SetPrefix(fmt.Sprintf("pid-%d-", os.Getpid()))
-}
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -28,13 +28,6 @@ func resourceGUEST() *schema.Resource {
 				Default:     nil,
 				Description: "Source vm path on esxi host to clone.",
 			},
-			"host_ovf": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     nil,
-				Description: "Path on esxi host of ovf files.",
-			},
 			"ovf_source": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -73,7 +66,7 @@ func resourceGUEST() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Default:     "thin",
-				Description: "Guest boot disk type. thin, zeroedthick, eagerzeroedthick",
+				Description: "Guest boot disk type: thin (default), zeroedthick, eagerzeroedthick",
 			},
 			"boot_disk_size": &schema.Schema{
 				Type:        schema.TypeString,
@@ -81,14 +74,14 @@ func resourceGUEST() *schema.Resource {
 				ForceNew:    false,
 				Computed:    true,
 				Default:     nil,
-				Description: "Guest boot disk size. Will expand boot disk to this size.",
+				Description: "Guest boot disk size in GB. Will expand boot disk to this size.",
 			},
 			"memsize": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Computed:    true,
-				Description: "Guest guest memory size.",
+				Description: "Guest guest memory size in MB",
 			},
 			"numvcpus": &schema.Schema{
 				Type:        schema.TypeString,

--- a/examples/08 ovftool on ESXi/README.md
+++ b/examples/08 ovftool on ESXi/README.md
@@ -1,0 +1,32 @@
+# Terraform esxi Provider (08 ovftool on ESXi)
+---
+
+Since we have SSH enabled on ESXi, it's possible to install ovftool directly on the ESXi host and avoid large network copies
+by hosting the OVA/OVFs locally. 
+
+To use this functionality, perform the following steps:
+1. Install ovftool somewhere on the ESXi host. For example, ``/vmfs/volumes/datastore1/ovftool`` (directory)
+2. Add the ``esxi_remote_ovftool_path`` to provider config:
+```
+provider "esxi" {
+  esxi_hostname      = "${var.esxi_server}"
+  esxi_username      = "${var.esxi_user}"
+  esxi_password      = "${var.esxi_password}"
+  esxi_remote_ovftool_path = "/vmfs/volumes/datastore1/ovftool/ovftool"
+}
+```
+3. Install an OVA somewhere on the ESXi host. For example, /vmfs/volumes/datastore1/ovas/ubuntu-22.04-server-cloudimg-amd64.ova
+4. Use the ``host_ovf://`` prefix to tell the plugin where to find the local image. Example:
+```
+resource "esxi_guest" "vmtest" {
+  ...
+   ovf_source = "host_ovf:///vmfs/volumes/datastore1/isos/ubuntu-22.04-server-cloudimg-amd64.ova"
+}
+```
+
+Now, when creating the vmtest instance, terraform will run the ovftool on the ESXi host directly and will pull the image on that
+same host, avoiding massive copies over the network. 
+
+Note that ovf_properties and guestinfo directives will work as expected. We highly recommend using guestinfo directive w/ cloud-init
+configs where possible (anything using cloud-init 21.2+ should work) and avoid the overhead of rebooting the instance multiple
+times.

--- a/examples/08 ovftool on ESXi/main.tf
+++ b/examples/08 ovftool on ESXi/main.tf
@@ -1,0 +1,23 @@
+provider "esxi" {
+  esxi_hostname      = var.esxi_hostname
+  esxi_hostport      = var.esxi_hostport
+  esxi_hostssl       = var.esxi_hostssl
+  esxi_username      = var.esxi_username
+  esxi_password      = var.esxi_password
+
+  esxi_remote_ovftool_path = "/vmfs/volumes/datastore1/ovftool/ovftool"
+}
+
+resource "esxi_guest" "vmtest" {
+  guest_name         = var.vm_hostname
+  disk_store         = var.disk_store
+
+  network_interfaces {
+     virtual_network = var.virtual_network
+  }
+
+  #
+  #  Specify an ovf file to use as a source.
+  #
+  ovf_source        = "host_ovf:///vmfs/volumes/datastore1/ovas/ubuntu-22.04-server-cloudimg-amd64.ova"
+}

--- a/examples/08 ovftool on ESXi/variables.tf
+++ b/examples/08 ovftool on ESXi/variables.tf
@@ -1,0 +1,37 @@
+#
+#  See https://www.terraform.io/intro/getting-started/variables.html for more details.
+#
+
+#  Change these defaults to fit your needs!
+
+variable "esxi_hostname" {
+  default = "esxi"
+}
+
+variable "esxi_hostport" {
+  default = "22"
+}
+
+variable "esxi_hostssl" {
+  default = "443"
+}
+
+variable "esxi_username" {
+  default = "root"
+}
+
+variable "esxi_password" {
+  # Unspecified will prompt
+}
+
+variable "virtual_network" {
+  default = "VM Network"
+}
+
+variable "disk_store" {
+  default = "DiskStore01"
+}
+
+variable "vm_hostname" {
+  default = "vmtest06"
+}

--- a/examples/08 ovftool on ESXi/versions.tf
+++ b/examples/08 ovftool on ESXi/versions.tf
@@ -1,0 +1,15 @@
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    esxi = {
+      source = "registry.terraform.io/josenk/esxi"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://github.com/josenk/terraform-provider-esxi
+      # https://registry.terraform.io/providers/josenk/esxi
+      #
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,12 @@ import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/josenk/terraform-provider-esxi/esxi"
+	"log"
 )
 
 func main() {
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
 			return esxi.Provider()


### PR DESCRIPTION
This PR adds support for invoking ovftool directly on the ESXi host and also enabling ESXi-local hosting of OVA/OVFs. This enables users to keep local copies of images, avoid massive network copies and generally speed up the process of setting up new VMs.