### PR TITLE
added example for cloud init networking

### DIFF
--- a/examples/08 Networking cloud init/main.tf
+++ b/examples/08 Networking cloud init/main.tf
@@ -1,0 +1,72 @@
+#########################################
+#  ESXI Provider host/login details
+#########################################
+#
+#   Use of variables here to hide/move the variables to a separate file
+#
+provider "esxi" {
+  esxi_hostname = var.esxi_hostname
+  esxi_hostport = var.esxi_hostport
+  esxi_hostssl  = var.esxi_hostssl
+  esxi_username = var.esxi_username
+  esxi_password = var.esxi_password
+}
+
+#########################################
+#  ESXI vSwitch resource
+#########################################
+#
+#  Example vswitch with defaults.
+#  Uncommend the uplink block to connect this vswitch to your nic.
+#
+resource "esxi_vswitch" "myvswitch" {
+  name = "My vSwitch"
+  #uplink {
+  #  name = "vmnic1"
+  #}
+}
+
+#########################################
+#  ESXI Port Group resource
+#########################################
+#
+#  Example port group with default, connecting to the above vswitch.
+#
+resource "esxi_portgroup" "myportgroup" {
+  name = "My Port Group"
+  vswitch = esxi_vswitch.myvswitch.name
+}
+
+#########################################
+#  ESXI Guest resource
+#########################################
+#
+#  This Guest VM is "bare-metal".   It will be powered on by default
+#  by terraform, but it will not boot to any OS.   It will however attempt
+#  to network boot on the port group configured above.
+#
+resource "esxi_guest" "vmtest01" {
+  guest_name = "vmtest01"
+  disk_store = "DS_001"
+  network_interfaces {
+    virtual_network = esxi_portgroup.myportgroup.name  # Connecting to the above portgroup
+  }
+
+  guestinfo = {
+    "metadata.encoding" = "gzip+base64"
+    "metadata"          = base64gzip(data.template_file.cloud-metadata.rendered)
+  }
+}
+
+data "template_file" "cloud-metadata" {
+    template = file("metadata.tpl")
+    vars = {
+      ipAddress = var.vmIP
+      gateway = var.vmGateway
+      nameserver = var.nameserver
+    }
+}
+
+output "ip" {
+  value = [esxi_guest.k3s-single-mode-vm.ip_address]
+}

--- a/examples/08 Networking cloud init/main.tf
+++ b/examples/08 Networking cloud init/main.tf
@@ -68,5 +68,5 @@ data "template_file" "cloud-metadata" {
 }
 
 output "ip" {
-  value = [esxi_guest.k3s-single-mode-vm.ip_address]
+  value = [esxi_guest.vmtest01.ip_address]
 }

--- a/examples/08 Networking cloud init/metadata.tpl
+++ b/examples/08 Networking cloud init/metadata.tpl
@@ -1,0 +1,24 @@
+network:
+    version: 2
+    ethernets:
+        ens192:
+            dhcp4: false
+            addresses:
+                - ${ipAddress}
+            gateway4: ${gateway}
+            nameservers:
+                addresses:
+                    - ${nameserver}
+
+# example
+# network:
+#     version: 2
+#     ethernets:
+#         ens192:
+#             dhcp4: false
+#             addresses:
+#                 - 10.10.10.1/24
+#             gateway4: 10.10.10.254
+#             nameservers:
+#                 addresses:
+#                     - 8.8.8.8

--- a/examples/08 Networking cloud init/variables.tf
+++ b/examples/08 Networking cloud init/variables.tf
@@ -1,0 +1,36 @@
+#
+#  See https://www.terraform.io/intro/getting-started/variables.html for more details.
+#
+
+#  Change these defaults to fit your needs!
+
+variable "esxi_hostname" {
+  default = "esxi"
+}
+
+variable "esxi_hostport" {
+  default = "22"
+}
+
+variable "esxi_hostssl" {
+  default = "443"
+}
+
+variable "esxi_username" {
+  default = "root"
+}
+
+variable "esxi_password" { # Unspecified will prompt 
+}
+
+variable "vmIP" {
+  default = "10.10.10.10/24"
+}
+
+variable "vmGateway" {
+  default = "10.10.10.1"
+}
+
+variable "nameserver" {
+  default = "8.8.8.8"
+}

--- a/examples/08 Networking cloud init/versions.tf
+++ b/examples/08 Networking cloud init/versions.tf
@@ -1,0 +1,15 @@
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    esxi = {
+      source = "registry.terraform.io/josenk/esxi"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://github.com/josenk/terraform-provider-esxi
+      # https://registry.terraform.io/providers/josenk/esxi
+      #
+    }
+  }
+}


### PR DESCRIPTION
had tried to add static IPv4 addresses via cloud init. Guess it could be helpful for all other's without googling around :)