### PR TITLE
Add support for AmazonLinux

### DIFF
--- a/esxi/guest-validations.go
+++ b/esxi/guest-validations.go
@@ -75,7 +75,9 @@ func validateGuestOsType(guestos string) bool {
 	}
 
 	//  All valid Guest OS's
-	allGuestOSs := [...]string{"asianux",
+	allGuestOSs := [...]string{
+		"amazonlinux",
+		"asianux",
 		"centos",
 		"coreos",
 		"darwin",


### PR DESCRIPTION
Validation fails if the guest was created with `amazonlinux2-64` specified.

```
 Error: Error: invalid guestos.  see https://github.com/josenk/vagrant-vmware-esxi/wiki/VMware-ESXi-6.5-guestOS-types
```