### PR TITLE
Allow guest Vm to run in ESXi nested host

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Configuration reference
     * key - Required - Key of the property
     * value - Required - Value of the property
   * ovf_properties_timer - Optional - Length of time to wait for ovf_properties to process.  Default 90s.
+  * nested_esxi - Optional - Set to "y" indicates that the guest can run in a ESXi nested environment
 
 
 * resource "esxi_vswitch"

--- a/esxi/guest_functions.go
+++ b/esxi/guest_functions.go
@@ -118,6 +118,7 @@ func updateVmx_contents(c *Config, vmid string, iscreate bool, memsize int, numv
 	if strings.Contains(vmx_contents, "Unable to find a VM corresponding") {
 		return nil
 	}
+	log.Printf("[updateVmx_contents] Current contents: %s\n", vmx_contents)
 
 	// modify memsize
 	if memsize != 0 {

--- a/esxi/resource_guest.go
+++ b/esxi/resource_guest.go
@@ -220,6 +220,13 @@ func resourceGUEST() *schema.Resource {
 				Computed:    true,
 				Description: "Guest notes (annotation).",
 			},
+			"nested_esxi": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Computed:    true,
+				Description: "Guest runs in nested ESXI",
+			},
 			"guestinfo": &schema.Schema{
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -258,6 +265,7 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 	boot_firmware := d.Get("boot_firmware").(string)
 	notes := d.Get("notes").(string)
 	power := d.Get("power").(string)
+	nested_esxi := d.Get("nested_esxi").(string)
 
 	if d.Get("guest_startup_timeout").(int) > 0 {
 		d.Set("guest_startup_timeout", d.Get("guest_startup_timeout").(int))
@@ -402,7 +410,7 @@ func resourceGUESTCreate(d *schema.ResourceData, m interface{}) error {
 
 	vmid, err := guestCREATE(c, guest_name, disk_store, src_path, resource_pool_name, memsize,
 		numvcpus, virthwver, guestos, boot_disk_type, boot_disk_size, virtual_networks, boot_firmware,
-		virtual_disks, guest_shutdown_timeout, ovf_properties_timer, notes, guestinfo, ovf_properties)
+		virtual_disks, guest_shutdown_timeout, ovf_properties_timer, notes, nested_esxi, guestinfo, ovf_properties)
 	if err != nil {
 		tmpint, _ = strconv.Atoi(vmid)
 		if tmpint > 0 {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/josenk/terraform-provider-esxi
+module github.com/narenas/terraform-provider-esxi
 
 require (
 	github.com/hashicorp/terraform v0.12.2

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/narenas/terraform-provider-esxi
+module github.com/josenk/terraform-provider-esxi
 
 require (
 	github.com/hashicorp/terraform v0.12.2

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/narenas/terraform-provider-esxi/esxi"
+	"github.com/josenk/terraform-provider-esxi/esxi"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/josenk/terraform-provider-esxi/esxi"
+	"github.com/narenas/terraform-provider-esxi/esxi"
 )
 
 func main() {


### PR DESCRIPTION
This comes from our use case, where we have an ESXi nested host and we have to set manually the proerty  monitor.allowLegacyCPU to TRUE. 

It works both, cloning the guest or creating it from and exixting template. 

```
resource "esxi_guest" "vmtest-tf" {
  guest_name              = "test"
  disk_store                 = "test"
  #guest_startup_timeout  = 600
  #boot_disk_size         = 1
  #memsize		  = 1024
  power	                  = "on"
  #numvcpus               = 1

  #
  #  Specify an existing guest to clone, an ovf source, or neither to build a bare-metal guest vm.
  #
  clone_from_vm      = "/source_machine"
  nested_esxi        = "y"

}
```
Please, feel free to let me know if there is something i should correct/improve as it is the first time i´m doing a PR and i would be happy to revise. 

Regards and thanks in advance.
